### PR TITLE
Added possibility to configure git root directory

### DIFF
--- a/plugin/src/functionalTest/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPluginFunctionalTest.kt
@@ -37,6 +37,38 @@ class GitHookPluginFunctionalTest {
             
             gitHooks {
                 gitHooksDirectory = project.layout.projectDirectory.dir("${gitHooksDir.path}")
+                gitDirectory = project.layout.projectDirectory.dir(".git")
+            }
+        """.trimIndent()
+        )
+
+        // Run the build
+        val runner = GradleRunner.create()
+        runner.forwardOutput()
+        runner.withPluginClasspath()
+        runner.withArguments("installGitHooks")
+        runner.withProjectDir(projectDir)
+        val result = runner.build()
+
+        // Verify the result
+        assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":installGitHooks")?.outcome
+        )
+        assertTrue {
+            gitHooksDestinationDir.exists()
+        }
+    }
+
+    @Test
+    fun `use convention`() {
+        gitHooksDir.mkdir()
+        // Set up the test build
+        settingsFile.writeText("")
+        buildFile.writeText(
+            """
+            plugins {
+                id('eu.bambooapps.gradle.plugin.githook')
             }
         """.trimIndent()
         )

--- a/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
+++ b/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
@@ -27,9 +27,10 @@ class GitHookPlugin : Plugin<Project> {
             description = "Copies the git hooks from /git-hooks to the .git folder."
             group = "git hooks"
             gitHooksDirectory = extension.gitHooksDirectory
-                .orElse(project.rootProject.layout.projectDirectory.dir("git-hooks"))
-            gitHooksDestinationDirectory = extension.gitDirectory.dir("hooks")
-                .orElse(project.rootProject.layout.projectDirectory.dir(".git/hooks"))
+                .convention(project.rootProject.layout.projectDirectory.dir("git-hooks"))
+            gitHooksDestinationDirectory = extension.gitDirectory
+                .convention(project.rootProject.layout.projectDirectory.dir(".git"))
+                .dir("hooks")
             onlyIf { isLinuxOrMacOs() }
         }
 

--- a/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
+++ b/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
@@ -27,6 +27,7 @@ class GitHookPlugin : Plugin<Project> {
             description = "Copies the git hooks from /git-hooks to the .git folder."
             group = "git hooks"
             gitHooksDirectory = extension.gitHooksDirectory
+                .orElse(project.rootProject.layout.projectDirectory.dir("git-hooks"))
             gitHooksDestinationDirectory = extension.gitDirectory.dir("hooks")
                 .orElse(project.rootProject.layout.projectDirectory.dir(".git/hooks"))
             onlyIf { isLinuxOrMacOs() }

--- a/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
+++ b/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHookPlugin.kt
@@ -5,6 +5,7 @@ package eu.bambooapps.gradle.plugin.githook
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.register
 import org.gradle.util.GradleVersion
@@ -25,10 +26,9 @@ class GitHookPlugin : Plugin<Project> {
         project.tasks.register<CopyGitHooks>("copyGitHooks") {
             description = "Copies the git hooks from /git-hooks to the .git folder."
             group = "git hooks"
-            gitHooksDirectory.set(extension.gitHooksDirectory)
-            gitHooksDestinationDirectory.set(
-                project.rootProject.layout.projectDirectory.dir(".git/hooks")
-            )
+            gitHooksDirectory = extension.gitHooksDirectory
+            gitHooksDestinationDirectory = extension.gitDirectory.dir("hooks")
+                .orElse(project.rootProject.layout.projectDirectory.dir(".git/hooks"))
             onlyIf { isLinuxOrMacOs() }
         }
 

--- a/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHooksExtension.kt
+++ b/plugin/src/main/kotlin/eu/bambooapps/gradle/plugin/githook/GitHooksExtension.kt
@@ -4,4 +4,5 @@ import org.gradle.api.file.DirectoryProperty
 
 interface GitHooksExtension {
     val gitHooksDirectory: DirectoryProperty
+    val gitDirectory: DirectoryProperty
 }


### PR DESCRIPTION
Added plugin extension option for specifying `.git` location explicitly. It uses convention which defaults to project root folder's `.git`.

Closes #1 